### PR TITLE
Improving logic, added optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Example of config structure:
 
 ```go
 type ConfigType struct {
- AppName   string `default:"app"`
- Version   string `default:"1"`
- Prefork   bool   `default:"false"`
+ AppName   string
+ Version   string
+ Prefork   bool
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,40 +12,49 @@ go get github.com/leonidasdeim/goconfig
 
 ## How to use
 
-Write config structure of your app. Actual config should be placed in root folder named `app_config.default.json`
-Example:
+Initial config that will store configuration information should be placed in root folder named `app.default.json`. Write config structure of your app.
+
+Example of config structure:
 
 ```go
 type ConfigType struct {
- AppName   string `json:"name"`
- Version   string `json:"version"`
- Prefork   bool   `json:"prefork"`
+ AppName   string `default:"app"`
+ Version   string `default:"1"`
+ Prefork   bool   `default:"false"`
 }
-```
-
-If you have modules which needs to be notified on config change, create similar enum:
-
-```go
-type ConfigSubscriber int
-const (
- FIRST_SUB ConfigSubscriber = iota
- SECOND_SUB
- NUMBER_OF_SUBS
-)
 ```
 
 Initialize and use config:
 
 ```go
-config, err := goconfig.Init[ConfigType](int(NUMBER_OF_SUBS))
+config := config.Init[ConfigType]()
+// access current configuration attributes
+cfg := config.GetCfg()
+cfg.AppName = "NewName"
+// update current configuration
+config.UpdateConfig(cfg)
+```
 
-updatedConfig := config.Get() // access current config 
-updatedConfig.AppName = "NewName"
-config.Update(updatedConfig) // update current config on-the-fly
+If you have modules which needs to be notified on config change, add a listener/subscriber:
+
+```go
+c.AddSubscriber("name_of_subscriber")
 ```
 
 Implement waiting goroutine for config change on the fly in your modules:
 
 ```go
-<-config.GetSubscriber(FIRST_SUB)
+_ = <-config.GetSubscriber("name_of_subscriber")
+```
+
+You can remove subscriber by given name on the fly as well:
+
+```go
+c.RemoveSubscriber("name_of_subscriber")
+```
+
+Library also support optional parameters with high order functions:
+
+```go
+config := config.Init[ConfigType](WithPath("./configuration_dir"), WithName("configuration_name"))
 ```

--- a/goconfig_test.go
+++ b/goconfig_test.go
@@ -2,7 +2,7 @@ package goconfig
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -13,39 +13,47 @@ type TestConfig struct {
 	Version int
 }
 
-var testData = TestConfig{"goconfig_test", 123}
+var testData = TestConfig{"config_test", 123}
 
-const testString = "{\"name\":\"goconfig_test\",\"version\":123}"
+const CONFIG_NAME = "test"
 
-func setUp(file string, data string, subs int) (*config[TestConfig], error) {
-	err := ioutil.WriteFile(file, []byte(data), 0644)
+const testString = "{\"name\":\"config_test\",\"version\":123}"
+
+func setUp(file string, data string, subscribers []string) (*config[TestConfig], error) {
+	err := os.WriteFile(fmt.Sprintf(file, CONFIG_NAME), []byte(data), RW_RW_R_PERMISSION)
+
 	if err != nil {
 		return nil, err
 	}
 
-	c, err := Init[TestConfig](subs)
+	c, err := Init[TestConfig](WithName(CONFIG_NAME))
 	if err != nil {
 		return nil, err
+	}
+
+	for _, subscriber := range subscribers {
+		c.AddSubscriber(subscriber)
 	}
 
 	return c, nil
 }
 
 func cleanUp() {
-	os.Remove(defaultConfig)
-	os.Remove(activeConfig)
+	os.Remove(fmt.Sprintf(DEFAULT_CONFIG, CONFIG_NAME))
+	os.Remove(fmt.Sprintf(ACTIVE_CONFIG, CONFIG_NAME))
 }
 
 func Test_Init(t *testing.T) {
 	t.Run("No configuration files", func(t *testing.T) {
-		_, err := Init[TestConfig](0)
+		_, err := Init[TestConfig](WithName("not_exist"))
 		if err == nil {
 			t.Errorf("Error is not returned unexpectedly")
 		}
 	})
 
 	t.Run("Check loaded config data", func(t *testing.T) {
-		c, err := setUp(defaultConfig, testString, 0)
+		c, err := setUp(ACTIVE_CONFIG, testString, []string{})
+
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
@@ -53,14 +61,15 @@ func Test_Init(t *testing.T) {
 		defer cleanUp()
 
 		want := testData
-		got := *c.Get()
+		got := *c.GetCfg()
+
 		if !reflect.DeepEqual(want, got) {
 			t.Error("Expected config does not match the result")
 		}
 	})
 
 	t.Run("Check loaded config data from active config", func(t *testing.T) {
-		c, err := setUp(activeConfig, testString, 0)
+		c, err := setUp(ACTIVE_CONFIG, testString, []string{})
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
@@ -68,28 +77,28 @@ func Test_Init(t *testing.T) {
 		defer cleanUp()
 
 		want := testData
-		got := *c.Get()
+		got := *c.GetCfg()
 		if !reflect.DeepEqual(want, got) {
 			t.Error("Expected config does not match the result")
 		}
 	})
 
 	t.Run("Create active config file", func(t *testing.T) {
-		_, err := setUp(defaultConfig, testString, 0)
+		_, err := setUp(ACTIVE_CONFIG, testString, []string{})
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
 		}
 		defer cleanUp()
 
-		if !fileExists(activeConfig) {
+		if !fileExists(fmt.Sprintf(ACTIVE_CONFIG, CONFIG_NAME)) {
 			t.Error("Expected active config file to be created, but it does not exist")
 		}
-		os.Remove(activeConfig)
+		os.Remove(fmt.Sprintf(ACTIVE_CONFIG, CONFIG_NAME))
 	})
 
 	t.Run("Check active config file content", func(t *testing.T) {
-		_, err := setUp(defaultConfig, testString, 0)
+		_, err := setUp(DEFAULT_CONFIG, testString, []string{})
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
@@ -97,7 +106,7 @@ func Test_Init(t *testing.T) {
 		defer cleanUp()
 
 		fileContent := TestConfig{}
-		configFile, err := os.Open(activeConfig)
+		configFile, err := os.Open(fmt.Sprintf(ACTIVE_CONFIG, CONFIG_NAME))
 		if err != nil {
 			t.Error("Opening activeConfig file", err.Error())
 		}
@@ -109,13 +118,14 @@ func Test_Init(t *testing.T) {
 
 		want := testData
 		got := fileContent
+
 		if !reflect.DeepEqual(want, got) {
 			t.Error("Expected config does not match the result")
 		}
 	})
 
 	t.Run("Check timestamp is created", func(t *testing.T) {
-		c, err := setUp(defaultConfig, testString, 0)
+		c, err := setUp(DEFAULT_CONFIG, testString, []string{})
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
@@ -128,29 +138,32 @@ func Test_Init(t *testing.T) {
 	})
 
 	t.Run("Check subscribers being created", func(t *testing.T) {
-		const NUM_OF_SUBS = 5
-		c, err := setUp(defaultConfig, testString, NUM_OF_SUBS)
+		subscribers := [5]string{"test1", "test2", "test3", "test4", "test5"}
+
+		c, err := setUp(DEFAULT_CONFIG, testString, subscribers[:])
+
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
 		}
+
 		defer cleanUp()
 
-		if len(c.subscribers) != NUM_OF_SUBS {
+		if len(c.subscribers) != len(subscribers) {
 			t.Error("Expected number of subscribers is not correct")
 		}
 	})
 
 	t.Run("Check subscribers not being notified", func(t *testing.T) {
-		const NUM_OF_SUBS = 1
-		c, err := setUp(defaultConfig, testString, NUM_OF_SUBS)
+		subscribers := [5]string{"test1"}
+		c, err := setUp(DEFAULT_CONFIG, testString, subscribers[:])
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
 		}
 		defer cleanUp()
 
-		if len(*c.GetSubscriber(0)) != 0 {
+		if len(c.GetSubscriber("test1")) != 0 {
 			t.Error("Subscribers has been notified")
 		}
 	})
@@ -160,7 +173,7 @@ func Test_Update(t *testing.T) {
 	newData := TestConfig{"new_data", 456}
 
 	t.Run("Check if config is updated", func(t *testing.T) {
-		c, err := setUp(defaultConfig, testString, 0)
+		c, err := setUp(DEFAULT_CONFIG, testString, []string{})
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
@@ -170,40 +183,47 @@ func Test_Update(t *testing.T) {
 		c.Update(newData)
 
 		want := newData
-		got := *c.Get()
+		got := *c.GetCfg()
 		if !reflect.DeepEqual(want, got) {
 			t.Error("Expected config does not match the result")
 		}
 	})
 
 	t.Run("Check if subscribers are being notified", func(t *testing.T) {
-		c, err := setUp(defaultConfig, testString, 3)
+		subscribers := [5]string{"test1", "test2", "test3"}
+
+		c, err := setUp(DEFAULT_CONFIG, testString, subscribers[:])
+
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
 		}
+
 		defer cleanUp()
 
 		c.Update(newData)
 
-		if len(c.subscribers[0]) != 1 || len(c.subscribers[1]) != 1 || len(c.subscribers[2]) != 1 {
+		if len(c.subscribers["test1"]) != 1 || len(c.subscribers["test2"]) != 1 || len(c.subscribers["test3"]) != 1 {
 			t.Error("Subscribers not being notified")
 		}
 	})
 
 	t.Run("Check if channels not being overloaded", func(t *testing.T) {
-		c, err := setUp(defaultConfig, testString, 1)
+		subscribers := [1]string{"test1"}
+		c, err := setUp(DEFAULT_CONFIG, testString, subscribers[:])
+
 		if err != nil {
 			t.Error("Error while setting up test")
 			t.FailNow()
 		}
+
 		defer cleanUp()
 
 		c.Update(newData)
 		c.Update(newData)
 		c.Update(newData)
 
-		if len(c.subscribers[0]) != 1 {
+		if len(c.subscribers["test1"]) != 1 {
 			t.Error("Subscribers not being notified")
 		}
 	})


### PR DESCRIPTION
Improving configuration logic overall:
- Subscribers can be added by using separate method after config is initialised. Now it is possible to use subscribers names instead of enum with numbers.
- It is possible to remove subscribers if they are not needed
- Added optional parameters logic, so it would be possible to change application configuration name and path. If I want to keep configuration not in root project path, but in config folder I can pass path with WithPath higher order optional function
- Added mutex when modification is done during access to subscribers